### PR TITLE
针对 NoneBot2 2.0.0b2 的修复

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,7 @@
 
 ## 适用版本
 
-- [`go-cqhttp` >= `1.0.0-beta8`](https://github.com/Mrs4s/go-cqhttp/releases/tag/v1.0.0-beta8)
-  - 已支持[`1.0.0-beta8-fix1`](https://github.com/Mrs4s/go-cqhttp/releases/tag/v1.0.0-beta8-fix1)新加入的事件
+- `go-cqhttp` >= `1.0.0-beta8-fix2`
 - `NoneBot2` >= `2.0.0b1`
 
 ## 支持功能

--- a/nonebot_plugin_guild_patch/models.py
+++ b/nonebot_plugin_guild_patch/models.py
@@ -41,7 +41,7 @@ class GuildMessageEvent(MessageEvent):
         if isinstance(raw_message, str):
             return raw_message
         elif isinstance(raw_message, list):
-            return str(Message(raw_message))
+            return str(Message(Message._construct(raw_message)))
         raise ValueError("unknown raw message type")
 
 

--- a/nonebot_plugin_guild_patch/models.py
+++ b/nonebot_plugin_guild_patch/models.py
@@ -8,7 +8,7 @@ from nonebot.adapters.onebot.v11 import (
     NoticeEvent,
 )
 from nonebot.log import logger
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, Field, parse_obj_as, validator
 from typing_extensions import Literal
 
 Event_T = TypeVar("Event_T", bound=Type[Event])
@@ -41,7 +41,7 @@ class GuildMessageEvent(MessageEvent):
         if isinstance(raw_message, str):
             return raw_message
         elif isinstance(raw_message, list):
-            return str(Message(Message._construct(raw_message)))
+            return str(parse_obj_as(Message, raw_message))
         raise ValueError("unknown raw message type")
 
 


### PR DESCRIPTION
NoneBot2 `2.0.0b2` 对 `Message` 类构造函数进行了一些[改动](https://github.com/nonebot/nonebot2/commit/e887c3999866cf84694653b8369c9383c1e884e2#diff-ba7959439c99732b20b0552817fc6c216ecb952cbc5d449ea7c08aee18441bc1R102-R103)，传入 `list[dict]` 时不再调用 `Message._construct`，并在 `Message.append` 中抛出异常，进而导致 Pydantic 验证失败和后续一系列连锁问题。这一修复通过 ~~主动调用 `Message._construct`~~ 使用 `pydantic.parse_obj_as` 构造消息序列解决问题。

可在我的系统环境中正常使用：

- Windows 11 x64
- Python `3.10.2`
- go-cqhttp `1.0.0-rc1` 与 `1.0.0-beta8-fix2` 均已测试
- NoneBot2 `2.0.0b2` 与 `2.0.0b1` 均已测试

另：go-cqhttp `1.0.0-beta8-fix1` （至少在我的电脑上）完全无法登录，所以先移除了（